### PR TITLE
Fix TypeError in create.py: use hash_password() instead of sha_new()

### DIFF
--- a/Mailman/Cgi/create.py
+++ b/Mailman/Cgi/create.py
@@ -31,7 +31,7 @@ from Mailman import Errors
 from Mailman import i18n
 from Mailman.htmlformat import *
 from Mailman.Logging.Syslog import syslog
-from Mailman.Utils import sha_new
+from Mailman.Utils import sha_new, hash_password
 
 # Set up i18n
 _ = i18n._
@@ -199,7 +199,7 @@ def process_request(doc, cgidata):
         # Install the emergency shutdown signal handler
         signal.signal(signal.SIGTERM, sigterm_handler)
 
-        pw = sha_new(password).hexdigest()
+        pw = hash_password(password)
         # Guarantee that all newly created files have the proper permission.
         # proper group ownership should be assured by the autoconf script
         # enforcing that all directories have the group sticky bit set


### PR DESCRIPTION
## Summary

- `sha_new(password).hexdigest()` in `Mailman/Cgi/create.py` raises `TypeError: Strings must be encoded before hashing` in Python 3 because `sha_new()` requires bytes, not str
- Rather than just adding `.encode()`, this switches to `hash_password()` (PBKDF2-SHA256) so newly created lists get the modern password format from day one instead of SHA1 that `update` would immediately flag for upgrade
- Imports `hash_password` alongside the existing `sha_new` import

Fixes #24.

## Test plan

- [ ] Create a new list via the `/create` web interface with a site password
- [ ] Verify no TypeError in the error log
- [ ] Verify the new list's password is stored in PBKDF2 format (starts with `$pbkdf2$sha256$`)
- [ ] Verify list admin login works after creation