### PR TITLE
Fix convert_to_utf8 build failure on systems where python3 is not in /usr/bin

### DIFF
--- a/scripts/convert_to_utf8
+++ b/scripts/convert_to_utf8
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/templates/Makefile.in
+++ b/templates/Makefile.in
@@ -31,6 +31,7 @@ CC=		@CC@
 CHMOD=  	@CHMOD@
 INSTALL=	@INSTALL@
 TRUE=		@TRUE@
+PYTHON=		@PYTHON@
 
 DEFS=   	@DEFS@
 
@@ -61,7 +62,7 @@ all: converttemplates
 
 # Use a stamp file to track conversion, so it only happens once
 .converted.stamp:
-	../scripts/convert_to_utf8 -d .
+	$(PYTHON) ../scripts/convert_to_utf8 -d .
 	touch .converted.stamp
 
 converttemplates: .converted.stamp


### PR DESCRIPTION
`scripts/convert_to_utf8` has a hardcoded `#!/usr/bin/python3` shebang, which fails on FreeBSD and other systems where Python 3 lives under `/usr/local/bin`. The build dies in the `templates/` step with `exec(../scripts/convert_to_utf8): No such file or directory`.

Two changes:

- Change the shebang to `#!/usr/bin/env python3` for portability
- Add `PYTHON= @PYTHON@` to `templates/Makefile.in` and invoke the script as `$(PYTHON) ../scripts/convert_to_utf8` so the build always uses the interpreter detected by `configure`, consistent with every other `Makefile.in` in the tree