### PR TITLE
tests: replace deprecated failIf/failUnless with assertFalse/assertTrue

### DIFF
--- a/tests/test_bounces.py
+++ b/tests/test_bounces.py
@@ -217,8 +217,8 @@ class BounceTest(unittest.TestCase):
             msg = email.message_from_file(fp)
         finally:
             fp.close()
-        self.failIf(msg['x-mailer'] is not None)
-        self.failIf(SMTP32.process(msg))
+        self.assertFalse(msg['x-mailer'] is not None)
+        self.assertFalse(SMTP32.process(msg))
 
     def test_caiwireless(self):
         from Mailman.Bouncers import Caiwireless

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -143,8 +143,8 @@ From: aperson@dom.ain
         eq(qmsg.get_content_type(), 'text/plain')
         eq(qmsg.get_param('charset'), 'us-ascii')
         msgid = qmsg['message-id']
-        self.failUnless(msgid.startswith('<mailman.'))
-        self.failUnless(msgid.endswith('._xtest@dom.ain>'))
+        self.assertTrue(msgid.startswith('<mailman.'))
+        self.assertTrue(msgid.endswith('._xtest@dom.ain>'))
         eq(qmsg.get_payload(), """\
 Your message entitled
 
@@ -183,8 +183,8 @@ Subject: Wish you were here
         eq(qmsg.get_content_type(), 'text/plain')
         eq(qmsg.get_param('charset'), 'us-ascii')
         msgid = qmsg['message-id']
-        self.failUnless(msgid.startswith('<mailman.'))
-        self.failUnless(msgid.endswith('._xtest@dom.ain>'))
+        self.assertTrue(msgid.startswith('<mailman.'))
+        self.assertTrue(msgid.endswith('._xtest@dom.ain>'))
         eq(qmsg.get_payload(), """\
 Your message entitled
 
@@ -207,7 +207,7 @@ class TestAfterDelivery(TestBase):
         last_post_time = mlist.last_post_time
         post_id = mlist.post_id
         AfterDelivery.process(mlist, None, None)
-        self.failUnless(mlist.last_post_time > last_post_time)
+        self.assertTrue(mlist.last_post_time > last_post_time)
         self.assertEqual(mlist.post_id, post_id + 1)
 
 
@@ -228,7 +228,7 @@ Approved: wazoo
 """)
         msgdata = {}
         Approve.process(mlist, msg, msgdata)
-        self.failUnless('approved' in msgdata)
+        self.assertTrue('approved' in msgdata)
         self.assertEqual(msgdata['approved'], 1)
 
     def test_approve_moderator(self):
@@ -240,7 +240,7 @@ Approve: wazoo
 """)
         msgdata = {}
         Approve.process(mlist, msg, msgdata)
-        self.failUnless('approved' in msgdata)
+        self.assertTrue('approved' in msgdata)
         self.assertEqual(msgdata['approved'], 1)
 
     def test_approved_admin(self):
@@ -252,7 +252,7 @@ Approved: wazoo
 """)
         msgdata = {}
         Approve.process(mlist, msg, msgdata)
-        self.failUnless('approved' in msgdata)
+        self.assertTrue('approved' in msgdata)
         self.assertEqual(msgdata['approved'], 1)
 
     def test_approve_admin(self):
@@ -264,7 +264,7 @@ Approve: wazoo
 """)
         msgdata = {}
         Approve.process(mlist, msg, msgdata)
-        self.failUnless('approved' in msgdata)
+        self.assertTrue('approved' in msgdata)
         self.assertEqual(msgdata['approved'], 1)
 
     def test_unapproved(self):
@@ -314,7 +314,7 @@ From: dperson@dom.ain
 
 """, Message.Message)
         CalcRecips.process(self._mlist, msg, msgdata)
-        self.failUnless('recips' in msgdata)
+        self.assertTrue('recips' in msgdata)
         recips = msgdata['recips']
         recips.sort()
         self.assertEqual(recips, ['aperson@dom.ain', 'bperson@dom.ain',
@@ -329,7 +329,7 @@ From: cperson@dom.ain
         self._mlist.setMemberOption('cperson@dom.ain',
                                     mm_cfg.DontReceiveOwnPosts, 1)
         CalcRecips.process(self._mlist, msg, msgdata)
-        self.failUnless('recips' in msgdata)
+        self.assertTrue('recips' in msgdata)
         recips = msgdata['recips']
         recips.sort()
         self.assertEqual(recips, ['aperson@dom.ain', 'bperson@dom.ain'])
@@ -343,7 +343,7 @@ Urgent: xxXXxx
 
 """, Message.Message)
         CalcRecips.process(self._mlist, msg, msgdata)
-        self.failUnless('recips' in msgdata)
+        self.assertTrue('recips' in msgdata)
         recips = msgdata['recips']
         recips.sort()
         self.assertEqual(recips, ['aperson@dom.ain', 'bperson@dom.ain',
@@ -360,7 +360,7 @@ Urgent: xxXXxx
 
 """, Message.Message)
         CalcRecips.process(self._mlist, msg, msgdata)
-        self.failUnless('recips' in msgdata)
+        self.assertTrue('recips' in msgdata)
         recips = msgdata['recips']
         recips.sort()
         self.assertEqual(recips, ['aperson@dom.ain', 'bperson@dom.ain',
@@ -587,7 +587,7 @@ Subject: Re: [XTEST] About Mailman...
 """, Message.Message)
         CookHeaders.process(self._mlist, msg, {})
         # prefixing depends on mm_cfg.py
-        self.failUnless(str(msg['subject']) == 'Re: [XTEST] About Mailman...' or
+        self.assertTrue(str(msg['subject']) == 'Re: [XTEST] About Mailman...' or
                         str(msg['subject']) == '[XTEST] Re: About Mailman...')
 
     def test_reply_to_list(self):
@@ -1273,7 +1273,7 @@ From: aperson@dom.ain
         data = self._mlist.pend_confirm(cookie)
         eq(data, ('H', 1))
         heldmsg = os.path.join(mm_cfg.DATA_DIR, 'heldmsg-_xtest-1.pck')
-        self.failUnless(os.path.exists(heldmsg))
+        self.assertTrue(os.path.exists(heldmsg))
         os.unlink(heldmsg)
         holdfiles = [f for f in os.listdir(mm_cfg.DATA_DIR)
                      if f.startswith('heldmsg-')]
@@ -1974,7 +1974,7 @@ It rocks!
         eq(data['_parsemsg'], False)
         eq(data['version'], 3)
         # Clock skew makes this unreliable
-        #self.failUnless(data['received_time'] <= time.time())
+        #self.assertTrue(data['received_time'] <= time.time())
         eq(msg.as_string(unixfrom=0), msg2.as_string(unixfrom=0))
 
 
@@ -2085,7 +2085,7 @@ It rocks!
         eq(len(files), 1)
         msg2, data = self._sb.dequeue(files[0])
         eq(msg.as_string(unixfrom=0), msg2.as_string(unixfrom=0))
-        self.failUnless(len(data) >= 6 and len(data) <= 7)
+        self.assertTrue(len(data) >= 6 and len(data) <= 7)
         eq(data['foo'], 1)
         eq(data['bar'], 2)
         eq(data['version'], 3)
@@ -2094,7 +2094,7 @@ It rocks!
         # Can't test verp. presence/value depend on mm_cfg.py
         #eq(data['verp'], 1)
         # Clock skew makes this unreliable
-        #self.failUnless(data['received_time'] <= time.time())
+        #self.assertTrue(data['received_time'] <= time.time())
 
 
 
@@ -2142,7 +2142,7 @@ Mailman rocks!
         eq(data['version'], 3)
         eq(data['listname'], '_xtest')
         # Clock skew makes this unreliable
-        #self.failUnless(data['received_time'] <= time.time())
+        #self.assertTrue(data['received_time'] <= time.time())
 
 
 

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -34,7 +34,7 @@ class TestLockFile(unittest.TestCase):
         lf1 = LockFile(LOCKFILE_NAME)
         lf2 = LockFile(LOCKFILE_NAME)
         lf1.lock()
-        self.failIf(lf2.locked())
+        self.assertFalse(lf2.locked())
 
 
 

--- a/tests/test_membership.py
+++ b/tests/test_membership.py
@@ -44,7 +44,7 @@ class TestNoMembers(TestBase):
         eq(mlist.getMembers(), [])
         eq(mlist.getRegularMemberKeys(), [])
         eq(mlist.getDigestMemberKeys(), [])
-        self.failIf(mlist.isMember('nobody@dom.ain'))
+        self.assertFalse(mlist.isMember('nobody@dom.ain'))
         raises(NotAMemberError, mlist.getMemberKey, 'nobody@dom.ain')
         raises(NotAMemberError, mlist.getMemberCPAddress, 'nobody@dom.ain')
         eq(mlist.getMemberCPAddresses(('nobody@dom.ain', 'noperson@dom.ain')),
@@ -65,9 +65,9 @@ class TestNoMembers(TestBase):
         mlist.addNewMember('APerson@dom.AIN')
         eq(mlist.getMembers(), ['aperson@dom.ain'])
         eq(mlist.getRegularMemberKeys(), ['aperson@dom.ain'])
-        self.failUnless(mlist.isMember('APerson@dom.AIN'))
-        self.failUnless(mlist.isMember('aperson@dom.ain'))
-        self.failUnless(mlist.isMember('APERSON@DOM.AIN'))
+        self.assertTrue(mlist.isMember('APerson@dom.AIN'))
+        self.assertTrue(mlist.isMember('aperson@dom.ain'))
+        self.assertTrue(mlist.isMember('APERSON@DOM.AIN'))
         eq(mlist.getMemberCPAddress('aperson@dom.ain'), 'APerson@dom.AIN')
         eq(mlist.getMemberCPAddress('APerson@dom.ain'), 'APerson@dom.AIN')
         eq(mlist.getMemberCPAddress('APERSON@DOM.AIN'), 'APerson@dom.AIN')
@@ -95,7 +95,7 @@ class TestMembers(TestBase):
         eq(mlist.getMembers(), ['person@dom.ain'])
         eq(mlist.getRegularMemberKeys(), ['person@dom.ain'])
         eq(mlist.getDigestMemberKeys(), [])
-        self.failUnless(mlist.isMember('person@dom.ain'))
+        self.assertTrue(mlist.isMember('person@dom.ain'))
         eq(mlist.getMemberKey('person@dom.ain'), 'person@dom.ain')
         eq(mlist.getMemberCPAddress('person@dom.ain'), 'person@dom.ain')
         eq(mlist.getMemberCPAddresses(('person@dom.ain', 'noperson@dom.ain')),
@@ -109,7 +109,7 @@ class TestMembers(TestBase):
 
     def test_authentication(self):
         mlist = self._mlist
-        self.failIf(mlist.authenticateMember('person@dom.ain', 'xxx'))
+        self.assertFalse(mlist.authenticateMember('person@dom.ain', 'xxx'))
         self.assertEqual(mlist.authenticateMember('person@dom.ain', 'xxXXxx'),
                          'xxXXxx')
 
@@ -121,7 +121,7 @@ class TestMembers(TestBase):
         eq(mlist.getMembers(), [])
         eq(mlist.getRegularMemberKeys(), [])
         eq(mlist.getDigestMemberKeys(), [])
-        self.failIf(mlist.isMember('person@dom.ain'))
+        self.assertFalse(mlist.isMember('person@dom.ain'))
         raises(NotAMemberError, mlist.getMemberKey, 'person@dom.ain')
         raises(NotAMemberError, mlist.getMemberCPAddress, 'person@dom.ain')
         eq(mlist.getMemberCPAddresses(('person@dom.ain', 'noperson@dom.ain')),
@@ -161,7 +161,7 @@ class TestMembers(TestBase):
         eq(mlist.getMembers(), ['nice@dom.ain'])
         eq(mlist.getRegularMemberKeys(), ['nice@dom.ain'])
         eq(mlist.getDigestMemberKeys(), [])
-        self.failUnless(mlist.isMember('nice@dom.ain'))
+        self.assertTrue(mlist.isMember('nice@dom.ain'))
         eq(mlist.getMemberKey('nice@dom.ain'), 'nice@dom.ain')
         eq(mlist.getMemberCPAddress('nice@dom.ain'), 'nice@dom.ain')
         eq(mlist.getMemberCPAddresses(('nice@dom.ain', 'nonice@dom.ain')),
@@ -176,7 +176,7 @@ class TestMembers(TestBase):
         eq(mlist.getMembers(), ['nice@dom.ain'])
         eq(mlist.getRegularMemberKeys(), ['nice@dom.ain'])
         eq(mlist.getDigestMemberKeys(), [])
-        self.failIf(mlist.isMember('person@dom.ain'))
+        self.assertFalse(mlist.isMember('person@dom.ain'))
         raises(NotAMemberError, mlist.getMemberKey, 'person@dom.ain')
         raises(NotAMemberError, mlist.getMemberCPAddress, 'person@dom.ain')
         eq(mlist.getMemberCPAddresses(('person@dom.ain', 'noperson@dom.ain')),
@@ -196,7 +196,7 @@ class TestMembers(TestBase):
         mlist.setMemberPassword('person@dom.ain', 'yyYYyy')
         eq(mlist.getMemberPassword('person@dom.ain'), 'yyYYyy')
         eq(mlist.authenticateMember('person@dom.ain', 'yyYYyy'), 'yyYYyy')
-        self.failIf(mlist.authenticateMember('person@dom.ain', 'xxXXxx'))
+        self.assertFalse(mlist.authenticateMember('person@dom.ain', 'xxXXxx'))
 
     def test_set_language(self):
         self._mlist.available_languages.append('xx')
@@ -245,7 +245,7 @@ class TestMembers(TestBase):
         now = time.time()
         time.sleep(1)
         self._mlist.setDeliveryStatus('person@dom.ain', MemberAdaptor.BYUSER)
-        self.failUnless(
+        self.assertTrue(
             self._mlist.getDeliveryStatusChangeTime('person@dom.ain')
             > now)
         self._mlist.setDeliveryStatus('person@dom.ain', MemberAdaptor.ENABLED)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -37,7 +37,7 @@ from EmailBase import EmailBase
 class TestSentMessage1(EmailBase):
     def test_user_notification(self):
         eq = self.assertEqual
-        unless = self.failUnless
+        unless = self.assertTrue
         msg = Message.UserNotification(
             'aperson@dom.ain',
             '_xtest@dom.ain',
@@ -70,7 +70,7 @@ class TestSentMessage1(EmailBase):
 class TestSentMessage2(EmailBase):
     def test_bounce_message(self):
         eq = self.assertEqual
-        unless = self.failUnless
+        unless = self.assertTrue
         msg = email.message_from_string("""\
 To: _xtest@dom.ain
 From: nobody@dom.ain


### PR DESCRIPTION
`failIf()` and `failUnless()` are deprecated aliases for `assertFalse()` and `assertTrue()` that were removed in Python 3.12. This replaces all occurrences in the test suite.

Files changed:
- `tests/test_bounces.py`
- `tests/test_handlers.py`
- `tests/test_lockfile.py`
- `tests/test_membership.py`
- `tests/test_message.py`