### PR TITLE
Fix unclosed file ResourceWarnings in FileRecips and ToDigest

### DIFF
--- a/Mailman/Handlers/FileRecips.py
+++ b/Mailman/Handlers/FileRecips.py
@@ -37,7 +37,8 @@ def process(mlist, msg, msgdata):
         msgdata['recips'] = []
         return
     # Read all the lines out of the file, and strip them of the trailing nl
-    addrs = [line.strip() for line in fp.readlines()]
+    with fp:
+        addrs = [line.strip() for line in fp.readlines()]
     # If the sender is in that list, remove him
     sender = msg.get_sender()
     if mlist.isMember(sender):

--- a/Mailman/Handlers/ToDigest.py
+++ b/Mailman/Handlers/ToDigest.py
@@ -81,7 +81,10 @@ def process(mlist, msg, msgdata):
     try:
         with open(mboxfile, 'a+b') as mboxfp:
             mbox = Mailbox(mboxfp.name)
-            mbox.AppendMessage(msg)
+            try:
+                mbox.AppendMessage(msg)
+            finally:
+                mbox.close()
             # Calculate the current size of the accumulation file.  This will not tell
             # us exactly how big the MIME, rfc1153, or any other generated digest
             # message will be, but it's the most easily available metric to decide
@@ -155,6 +158,13 @@ def send_digests(mlist, mboxfp):
 
 def send_i18n_digests(mlist, mboxfp):
     mbox = Mailbox(mboxfp)
+    try:
+        _send_i18n_digests(mlist, mbox)
+    finally:
+        mbox.close()
+
+
+def _send_i18n_digests(mlist, mbox):
     # Prepare common information (first lang/charset)
     lang = mlist.preferred_language
     lcset = Utils.GetCharSet(lang)


### PR DESCRIPTION
Two handlers open file-like resources that are never explicitly closed, producing `ResourceWarning` under Python 3.

- `FileRecips.py`: `open(members.txt)` is read but never closed; wrap in `with fp:`.
- `ToDigest.py`: `Mailbox` (a `mailbox.mbox` subclass) opens its own internal file descriptor.  Two call sites never called `close()`:
  - `process()`: `Mailbox.AppendMessage()` now wrapped in `try/finally`
  - `send_i18n_digests()`: body extracted to `_send_i18n_digests()` so the `Mailbox` can be closed in a `finally` block before any early return

`try/finally` is used instead of a `with`-statement because `Mailbox` does not support the context manager protocol on all Python 3 builds (confirmed failing on FreeBSD Python 3.11).

Files changed:
- `Mailman/Handlers/FileRecips.py`
- `Mailman/Handlers/ToDigest.py`